### PR TITLE
Adiciona endpoint para obter todos os alimentos

### DIFF
--- a/WebScrapping-Backend/src/webscrapping.API/Controllers/FoodController.cs
+++ b/WebScrapping-Backend/src/webscrapping.API/Controllers/FoodController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using WebScrapping.Application.UseCases.Food.GetAll;
 using WebScrapping.Application.UseCases.Food.Scrap;
 using WebScrapping.Communication.Requests;
+using WebScrapping.Communication.Responses;
 
 namespace WebScrapping.API.Controllers;
 
@@ -9,10 +11,22 @@ namespace WebScrapping.API.Controllers;
 public class FoodController : ControllerBase
 {
     [HttpPost]
+    [ProducesResponseType(typeof(ResponseFoodsJson), StatusCodes.Status201Created)]
     public async Task<IActionResult> SearchFood(
         [FromServices] IScrapFoodsUseCase useCase)
     {
         var response = await useCase.Execute();
         return Created(string.Empty, response);
     }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(ResponseFoodsJson), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> GetAll(
+        [FromServices] IGetAllFoodsUseCase useCase)
+    {
+        var response = await useCase.Execute();
+        return Ok(response);
+    }
+
 }

--- a/WebScrapping-Backend/src/webscrapping.Application/DependecyInjectionExtension.cs
+++ b/WebScrapping-Backend/src/webscrapping.Application/DependecyInjectionExtension.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using WebScrapping.Application.AutoMapper;
+using WebScrapping.Application.UseCases.Food.GetAll;
 using WebScrapping.Application.UseCases.Food.Scrap;
 namespace WebScrapping.Application;
 
@@ -19,5 +20,6 @@ public static class DependecyInjectionExtension
     private static void AddUseCases(IServiceCollection services)
     {
         services.AddScoped<IScrapFoodsUseCase, ScrapFoodsUseCase>();
+        services.AddScoped<IGetAllFoodsUseCase, GetAllFoodsUseCase>();
     }
 }

--- a/WebScrapping-Backend/src/webscrapping.Application/UseCases/Food/GetAll/GetAllFoodsUseCase.cs
+++ b/WebScrapping-Backend/src/webscrapping.Application/UseCases/Food/GetAll/GetAllFoodsUseCase.cs
@@ -1,0 +1,25 @@
+﻿
+using AutoMapper;
+using WebScrapping.Communication.Responses;
+using WebScrapping.Domain.DataAccess.Repositories;
+
+namespace WebScrapping.Application.UseCases.Food.GetAll;
+
+public class GetAllFoodsUseCase : IGetAllFoodsUseCase
+{
+    private readonly IFoodReadOnlyRepository _repository;
+    private readonly IMapper _mapper;
+    public GetAllFoodsUseCase(
+        IFoodReadOnlyRepository repository,
+        IMapper mapper)
+    {
+        _repository = repository;
+        _mapper = mapper;
+    }
+
+    public async Task<List<ResponseFoodsJson>> Execute()
+    {
+        var result = await _repository.GetAll();
+        return _mapper.Map<List<ResponseFoodsJson>>(result);
+    }
+}

--- a/WebScrapping-Backend/src/webscrapping.Application/UseCases/Food/GetAll/IGetAllFoodsUseCase.cs
+++ b/WebScrapping-Backend/src/webscrapping.Application/UseCases/Food/GetAll/IGetAllFoodsUseCase.cs
@@ -1,0 +1,8 @@
+﻿using WebScrapping.Communication.Responses;
+
+namespace WebScrapping.Application.UseCases.Food.GetAll;
+
+public interface IGetAllFoodsUseCase
+{
+    Task<List<ResponseFoodsJson>> Execute();
+}


### PR DESCRIPTION
- Adição de novos namespaces no `FoodController.cs` para incluir os casos de uso `GetAll` e `Scrap`, além das requisições e respostas de comunicação.
- Adição de um novo endpoint `HttpGet` no `FoodController` para obter todos os alimentos, com os tipos de resposta `ResponseFoodsJson` para status 200 e status 204.
- Modificação no `DependecyInjectionExtension.cs` para adicionar a injeção de dependência do caso de uso `IGetAllFoodsUseCase`.
- Criação da classe `GetAllFoodsUseCase` que implementa a interface `IGetAllFoodsUseCase`, utilizando `IFoodReadOnlyRepository` e `IMapper` para buscar e mapear todos os alimentos.
- Criação da interface `IGetAllFoodsUseCase` que define o método `Execute` para retornar uma lista de `ResponseFoodsJson`.